### PR TITLE
release: v0.9

### DIFF
--- a/.github/workflows/development-checks.yml
+++ b/.github/workflows/development-checks.yml
@@ -2,9 +2,9 @@ name: Development Checks
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
-    branches: ["**"]
+    branches: [main]
 
 permissions:
   contents: read
@@ -92,3 +92,25 @@ jobs:
           format: spdx-json
           artifact-name: sbom.spdx.json
           output-file: sbom.spdx.json
+
+  development-checks:
+    name: development-checks
+    if: always()
+    needs: [lint, tests, validate-config, build, security, sbom]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all development checks passed
+        env:
+          LINT: ${{ needs.lint.result }}
+          TESTS: ${{ needs.tests.result }}
+          VALIDATE_CONFIG: ${{ needs.validate-config.result }}
+          BUILD: ${{ needs.build.result }}
+          SECURITY: ${{ needs.security.result }}
+          SBOM: ${{ needs.sbom.result }}
+        run: |
+          test "$LINT" = "success"
+          test "$TESTS" = "success"
+          test "$VALIDATE_CONFIG" = "success"
+          test "$BUILD" = "success"
+          test "$SECURITY" = "success"
+          test "$SBOM" = "success"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    if: github.repository == 'abdulrbasit/job-hunter'
+    if: github.repository == 'abdulrbasit/job-hunter' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -21,32 +21,27 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Compute next version
-        id: next_version
+      - name: Verify release commit
+        id: release_version
         run: |
-          python3 - <<'PY' >> $GITHUB_OUTPUT
+          VERSION=$(python3 - <<'PY'
           import tomllib
           with open("pyproject.toml", "rb") as f:
-              d = tomllib.load(f)
-          major, minor = d["project"]["version"].split(".")
-          major, minor = int(major), int(minor)
-          if minor >= 999:
-              major += 1
-              minor = 0
-          else:
-              minor += 1
-          print(f"version={major}.{minor}")
+              print(tomllib.load(f)["project"]["version"])
           PY
+          )
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Bump version and commit
-        env:
-          VERSION: ${{ steps.next_version.outputs.version }}
-        run: |
-          sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "release: v${VERSION}"
-          git push origin HEAD
+          SUBJECT=$(git log -1 --pretty=%s)
+          if [ "$SUBJECT" != "release: v${VERSION}" ]; then
+            echo "HEAD must be release: v${VERSION}; found: $SUBJECT"
+            exit 1
+          fi
+
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag already exists: v${VERSION}"
+            exit 1
+          fi
 
       - name: Build
         run: uv build
@@ -56,7 +51,7 @@ jobs:
 
       - name: Tag release
         env:
-          VERSION: ${{ steps.next_version.outputs.version }}
+          VERSION: ${{ steps.release_version.outputs.version }}
         run: |
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
@@ -64,7 +59,7 @@ jobs:
       - name: Announce release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.next_version.outputs.version }}
+          VERSION: ${{ steps.release_version.outputs.version }}
         run: |
           export PREV=$(git describe --tags --abbrev=0 "v${VERSION}^" 2>/dev/null || echo "")
           BODY=$(VERSION="$VERSION" PREV="$PREV" python3 scripts/release_notes.py)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ All four checks must pass before a PR. The PR template checklist reminds you, bu
 
 ```bash
 uv run pytest tests/ -q --tb=short
-uv run ruff format --check job_hunter tests
-uv run ruff check job_hunter tests
+uv run ruff format --check job_hunter tests scripts
+uv run ruff check job_hunter tests scripts
 uv run ty check job_hunter tests
 ```
 
@@ -54,7 +54,8 @@ No body, no bullet points, no `Co-authored-by` trailers.
 
 ## Project Rules
 
-- `config/job_hunter.yml` is the only durable user config file. Do not add new config files.
+- `config/job_hunter.yml` stores the main deterministic user settings.
+- `config/companies_browser.yml` stores optional browser-hunt company targets.
 - `outputs/state/discovered_urls.yml` is the persistent URL dedup store.
 - Treat `.claude/`, `config/`, and `profile/template-files/` as canonical workspace asset sources.
 - Mock external services in tests; no live network calls in the default suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "job-hunter-kit"
-version = "0.8"
+version = "0.9"
 description = "Job search automation with LLM API pipeline mode and AI agent mode."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,13 +68,34 @@ def test_schema_files_are_valid_json() -> None:
         json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_release_workflow_is_manual_only() -> None:
+def test_release_workflow_publishes_current_release_commit() -> None:
     workflow = yaml.safe_load((WORKFLOWS / "release.yml").read_text(encoding="utf-8"))
     # PyYAML parses `on:` as boolean True, not the string "on"
     triggers = workflow.get(True, {}) or {}
     assert "workflow_dispatch" in triggers, "release.yml must have workflow_dispatch trigger"
-    for auto_trigger in ("push", "pull_request", "schedule"):
-        assert auto_trigger not in triggers, f"release.yml must not have automatic trigger: {auto_trigger}"
+    assert set(triggers) == {"workflow_dispatch"}
+
+    jobs = workflow["jobs"]
+    assert set(jobs) == {"release"}
+    text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+    assert "git tag" in text
+    assert "git push origin" in text
+    assert "git commit" not in text
+    assert "git switch" not in text
+    assert "gh pr create" not in text
+    assert "pull-requests: write" not in text
+
+
+def test_development_checks_exposes_required_aggregate_job() -> None:
+    workflow = yaml.safe_load((WORKFLOWS / "development-checks.yml").read_text(encoding="utf-8"))
+    triggers = workflow.get(True, {}) or {}
+    jobs = workflow["jobs"]
+    aggregate = jobs["development-checks"]
+
+    assert triggers["push"]["branches"] == ["main"]
+    assert triggers["pull_request"]["branches"] == ["main"]
+    assert aggregate["name"] == "development-checks"
+    assert set(aggregate["needs"]) == {"lint", "tests", "validate-config", "build", "security", "sbom"}
 
 
 def test_workspace_template_find_jobs_exports_job_board_secrets() -> None:


### PR DESCRIPTION
Bumps Job Hunter to v0.9 and fixes the protected-main release flow.

- Release publishes and tags the existing release commit without pushing to `main`.
- Adds the required `development-checks` aggregate status.