### PR TITLE
Consumer-grade install and update (Windows/macOS/Linux)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  verify:
     if: github.repository == 'abdulrbasit/job-hunter' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-      contents: write
-      discussions: write
+    outputs:
+      version: ${{ steps.release_version.outputs.version }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
 
       - name: Verify release commit
         id: release_version
@@ -43,6 +36,72 @@ jobs:
             exit 1
           fi
 
+  # Builds the Layer 2 native installers (docs/{windows,macos}-packaging.md). Unsigned —
+  # see those docs for the SmartScreen warning (Windows) and right-click-Open workaround
+  # (macOS) until code-signing/notarization credentials are available. Linux keeps
+  # `uv tool install` as primary; packaging/linux/install.sh just wraps it.
+  build-installers:
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact: windows-installer
+          - os: macos-latest
+            artifact: macos-installer
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build PyInstaller bundle (Windows)
+        if: runner.os == 'Windows'
+        run: uv run --with pyinstaller pyinstaller --noconfirm --clean packaging/windows/job-hunter.spec
+
+      - name: Install Inno Setup (Windows)
+        if: runner.os == 'Windows'
+        run: choco install innosetup --no-progress -y
+
+      - name: Build installer (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: iscc packaging\windows\job-hunter.iss /DAppVersion=${{ needs.verify.outputs.version }}
+
+      - name: Build PyInstaller bundle (macOS)
+        if: runner.os == 'macOS'
+        run: uv run --with pyinstaller pyinstaller --noconfirm --clean packaging/macos/job-hunter.spec
+
+      - name: Build installer (macOS)
+        if: runner.os == 'macOS'
+        run: bash packaging/macos/build_pkg.sh ${{ needs.verify.outputs.version }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist-installer/*
+          if-no-files-found: error
+
+  release:
+    needs: [verify, build-installers]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: write
+      discussions: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
       - name: Build
         run: uv build
 
@@ -51,15 +110,33 @@ jobs:
 
       - name: Tag release
         env:
-          VERSION: ${{ steps.release_version.outputs.version }}
+          VERSION: ${{ needs.verify.outputs.version }}
         run: |
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist-installer
+
+      - name: Create GitHub Release with installers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          PREV=$(git describe --tags --abbrev=0 "v${VERSION}^" 2>/dev/null || echo "")
+          VERSION="$VERSION" PREV="$PREV" python3 scripts/release_notes.py > /tmp/release_notes.md
+          gh release create "v${VERSION}" \
+            dist-installer/windows-installer/* \
+            dist-installer/macos-installer/* \
+            packaging/linux/install.sh \
+            --title "job-hunter-kit v${VERSION}" \
+            --notes-file /tmp/release_notes.md
+
       - name: Announce release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.release_version.outputs.version }}
+          VERSION: ${{ needs.verify.outputs.version }}
         run: |
           export PREV=$(git describe --tags --abbrev=0 "v${VERSION}^" 2>/dev/null || echo "")
           BODY=$(VERSION="$VERSION" PREV="$PREV" python3 scripts/release_notes.py)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ jobs:
   verify:
     if: github.repository == 'abdulrbasit/job-hunter' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.release_version.outputs.version }}
     steps:
@@ -43,6 +45,8 @@ jobs:
   build-installers:
     needs: verify
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -13,15 +13,24 @@ Works interactively inside Claude Code or Codex (VS Code extensions), or runs fu
 
 ## Install
 
-Requires [Python 3.12 or 3.13](https://www.python.org/downloads/). See the
-complete beginner-friendly [SETUP.md](job_hunter/templates/workspace/SETUP.md)
-for installation, PATH troubleshooting, API-key links, and agent permissions.
+**Windows/macOS, no terminal:** download the installer from the
+[latest release](https://github.com/abdulrbasit/job-hunter/releases/latest),
+run it, and the dashboard opens. Unsigned — Windows SmartScreen and macOS
+Gatekeeper require an extra click through on first run (see
+[SETUP.md](job_hunter/templates/workspace/SETUP.md)).
+
+**Any OS, via terminal** — requires [Python 3.12 or 3.13](https://www.python.org/downloads/):
 
 ```bash
 uv tool install job-hunter-kit
 ```
 
-Standard install supports both agent and `llm-api` modes.
+Standard install supports both agent and `llm-api` modes. See the complete
+beginner-friendly [SETUP.md](job_hunter/templates/workspace/SETUP.md) for
+PATH troubleshooting, API-key links, and agent permissions.
+
+Once installed, updates are one click in the dashboard (`job-hunter dash` →
+"Update now") — no terminal needed for either install path.
 
 ## Quick Start
 

--- a/docs/linux-packaging.md
+++ b/docs/linux-packaging.md
@@ -62,3 +62,28 @@ PyInstaller, not exercised here).
 Per this repo's rules: **do not** publish, bump the version, or trigger a
 release from this spike without separate, explicit user authorization —
 unsigned artifacts may exist for internal CI only.
+
+## Bundling fix
+
+Same `catalog/companies.json`-doesn't-exist bug as Windows/macOS (see
+docs/windows-packaging.md) — fixed identically here: all four
+`job_hunter/catalog/*.json` files plus `job_hunter/companies/data/` and
+`job_hunter/locations/data/` are now bundled.
+
+## Install layer: bootstrap script, not the AppImage/PyInstaller spike
+
+Linux keeps `uv tool install` as the primary install path — the PyInstaller
+spike above is not wired into a shipped installer. `packaging/linux/install.sh`
+just automates the manual steps: installs `uv` if missing, runs `uv tool
+install job-hunter-kit`, registers a `~/.local/share/applications/job-hunter.desktop`
+launcher (reusing `packaging/linux/job-hunter.desktop`'s content), and opens
+the dashboard.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/abdulrbasit/job-hunter/main/packaging/linux/install.sh | sh
+```
+
+`.github/workflows/release.yml` attaches this script to each GitHub Release
+so the URL above always resolves to the version matching `main` at release
+time. AppImage wrapping of the PyInstaller spike (below) remains a possible
+future layer, not built now.

--- a/docs/macos-packaging.md
+++ b/docs/macos-packaging.md
@@ -34,3 +34,32 @@ action (`playwright install chromium`).
 Per this repo's rules: **do not** publish, bump the version, or trigger a
 release from this spike without separate, explicit user authorization —
 unsigned artifacts may exist for internal CI only.
+
+## Bundling fix carried over from the Windows spike
+
+The `datas` list here mirrored Windows/Linux exactly, so it inherited the
+same bug: `catalog/companies.json` no longer exists (company data moved to
+`job_hunter/companies/data/*.jsonl`; location data is a separate
+`job_hunter/locations/data/` tree). Fixed identically — bundles all four
+`job_hunter/catalog/*.json` files plus `job_hunter/companies/data/` and
+`job_hunter/locations/data/`. Unverified on real macOS hardware (same
+limitation as the rest of this doc), but the fix is mechanical and
+structurally identical to the Windows build, which was rebuilt and
+re-verified after this change (see docs/windows-packaging.md).
+
+## Installer layer: pkgbuild
+
+`packaging/macos/build_pkg.sh <version>` wraps the built `dist/Job
+Hunter.app` into an unsigned `.pkg` via `pkgbuild`. Also unbuilt/untested
+here — needs the same real Mac hardware called out above.
+`.github/workflows/release.yml`'s `build-installers` job runs it on a
+`macos-latest` runner, which will be the first real validation.
+
+```bash
+uv run --with pyinstaller pyinstaller --noconfirm --clean packaging/macos/job-hunter.spec
+bash packaging/macos/build_pkg.sh 0.25
+```
+
+Unsigned, so first launch needs right-click (Control-click) the app →
+**Open** → **Open**, instead of a normal double-click, until signing and
+notarization (above) are done.

--- a/docs/windows-packaging.md
+++ b/docs/windows-packaging.md
@@ -1,6 +1,8 @@
-# Windows packaging spike
+# Windows packaging
 
-Status: experimental. PyInstaller `onedir`, console enabled. Not part of release or PyPI workflows.
+Status: wired into `.github/workflows/release.yml` as the Windows installer build
+(manual `workflow_dispatch` only — never runs on every push). PyInstaller `onedir`,
+wrapped by Inno Setup into `Job-Hunter-Setup-<version>.exe`.
 
 Build from repository root:
 
@@ -62,3 +64,41 @@ real `hunt` network run. The `internal self-test` result is a meaningfully
 stronger proxy than before for "will the packaged data actually load," since
 it's the first frozen-build check that specifically exercises the new
 catalog/reference-data resources end-to-end.
+
+## Bug found and fixed: company/location data was never bundled
+
+The `datas` list dated from before the company-catalog migration off
+`catalog/companies.json` onto a runtime store seeded from
+`job_hunter/companies/data/*.jsonl`, plus `job_hunter/locations/data/`
+(cities, manifest). The spec still referenced the now-deleted
+`catalog/companies.json`, so a build **failed outright**
+(`Unable to find ... catalog\companies.json`) rather than silently shipping
+without company data. Fixed by bundling `job_hunter/catalog/*.json` (all
+four files, not three), `job_hunter/companies/data/`, and
+`job_hunter/locations/data/` — verified by rebuilding and running
+`internal self-test --json`: `catalog_resource` now reports "4087 companies
+across 61 countries" (previously would have failed to build at all).
+`doctor` against a fresh `init`'d workspace also passes
+`package_owned_locations`/`package_owned_filters`/`companies_store` (5178
+companies in the runtime store).
+
+## Installer layer: Inno Setup
+
+`packaging/windows/job-hunter.iss` wraps `dist/job-hunter/` (from the spec
+above) into a Windows installer with a Start Menu entry (`job-hunter.exe
+dash`) and an optional desktop shortcut checkbox. Authored against Inno
+Setup 6's documented syntax but **not compiled in this dev environment** (no
+Inno Setup toolchain installed here) — `.github/workflows/release.yml`'s
+`build-installers` job installs it via `choco install innosetup` and runs
+`iscc` on a `windows-latest` runner, which is the first environment that
+will actually validate this script compiles.
+
+```powershell
+uv run --with pyinstaller pyinstaller --noconfirm --clean packaging/windows/job-hunter.spec
+iscc packaging/windows/job-hunter.iss /DAppVersion=0.25
+```
+
+Unsigned — no code-signing certificate is available yet, so first run shows
+a Windows SmartScreen warning ("Windows protected your PC" → "More info" →
+"Run anyway"). A real certificate is a follow-up, same as macOS
+notarization.

--- a/docs/workspace-updates.md
+++ b/docs/workspace-updates.md
@@ -1,7 +1,45 @@
 # Workspace Updates
 
 What `job-hunter update` actually does, for anyone debugging an update or
-changing what it touches.
+changing what it touches. See also the in-app one-click update flow below,
+which runs this command as one step of a larger upgrade.
+
+## In-app one-click update (`job_hunter/update/`)
+
+The dashboard checks PyPI for a newer `job-hunter-kit` on launch (cached,
+24h TTL, never blocks startup — `update/versions.py`) and shows an "Update
+now" banner when one exists. Clicking it (`DashAPI.start_self_update`,
+`ux/web/api.py`):
+
+1. Refuses if a hunt is running (shares the existing hunt lock).
+2. Detects the installer (`update/upgrader.py`: `uv tool`, `pipx`, or
+   `pip` — checked in that order via `uv tool list`/`pipx list`; a frozen
+   PyInstaller build (`sys.frozen`) has none of these, so it reports a
+   copyable fallback command instead of attempting an in-app upgrade).
+3. Snapshots the exact files `update_workspace_assets`/`update_skills`/
+   `update_workflows` are about to overwrite (`update/snapshot.py`) into
+   `outputs/state/update_snapshot/` — only the single most recent snapshot
+   is kept, so this undoes the *last* update, not arbitrary history.
+   Restore it with `job-hunter internal rollback-update`.
+4. Spawns `job-hunter internal self-update` **detached** and closes the
+   dashboard window. The upgrade can't happen in-process — Windows locks
+   the running executable, and every OS keeps old code loaded in memory
+   regardless.
+5. That detached process (`update/self_update.py`) runs the upgrade
+   command (retrying a few times — the exiting dashboard process may hold
+   the executable briefly), then runs `job-hunter update --yes` — this is
+   the same command documented below, just invoked automatically — then
+   relaunches `job-hunter dash`.
+6. The result is written to `platform_config_dir()/last_update.json` and
+   surfaced once as a toast on the next dashboard launch
+   (`get_last_update_result`, consumed on read).
+
+All of this state — the version-check cache, the last-update result — lives
+in `launcher.platform_config_dir()` (`%APPDATA%`/`~/Library/Application
+Support`/`$XDG_CONFIG_HOME`), not the workspace. Snapshots live under
+`outputs/state/`, which is already user-owned/regenerable per
+[DATA_CONTRACT.md](../DATA_CONTRACT.md). No new user-editable config file or
+schema change — `config/job_hunter.yml` stays the only one.
 
 ## The steps (`cli/commands/update.py::update`)
 

--- a/job_hunter/cli/commands/dashboard.py
+++ b/job_hunter/cli/commands/dashboard.py
@@ -11,11 +11,18 @@ from job_hunter.cli.options import JSON_OPTION, WORKSPACE_OPTION
 
 
 @app.command()
-def dash() -> None:
+def dash(
+    no_shortcut: bool = typer.Option(False, "--no-shortcut", help="Skip creating a desktop shortcut"),
+) -> None:
     """Open the native web dashboard."""
     from job_hunter.config.loader import ROOT
+    from job_hunter.shortcut import ensure_desktop_shortcut, record_opt_out
     from job_hunter.ux.web import launch
 
+    if no_shortcut:
+        record_opt_out()
+    else:
+        ensure_desktop_shortcut()
     launch(ROOT)
 
 

--- a/job_hunter/cli/commands/update.py
+++ b/job_hunter/cli/commands/update.py
@@ -132,10 +132,48 @@ def update(
     _echo_telemetry_warnings(install_telemetry(root))
 
 
+@internal_app.command(name="self-update")
+def self_update_cmd(
+    workspace: str = WORKSPACE_OPTION,
+    from_version: str = typer.Option(..., "--from-version"),
+) -> None:
+    """Upgrade the installed package and relaunch the dashboard.
+
+    Spawned detached by the dashboard's one-click update button
+    (DashAPI.start_self_update) right before its window closes — not meant to be run
+    directly.
+    """
+    from job_hunter.update.self_update import run_self_update
+    from job_hunter.update.upgrader import detect_upgrader
+
+    upgrader = detect_upgrader()
+    if upgrader is None:
+        typer.echo("[self-update] could not detect how job-hunter-kit was installed", err=True)
+        raise typer.Exit(1)
+    result = run_self_update(Path(workspace), upgrader, from_version=from_version)
+    if not result["ok"]:
+        typer.echo(f"[self-update] failed at {result['stage']}: {result['message']}", err=True)
+        raise typer.Exit(1)
+    typer.echo(f"[self-update] upgraded {result['from']} -> {result['to']}")
+
+
+@internal_app.command(name="rollback-update")
+def rollback_update_cmd(workspace: str = WORKSPACE_OPTION) -> None:
+    """Restore workspace assets/skills/workflows from the last pre-update snapshot."""
+    from job_hunter.update.snapshot import rollback_last
+
+    count = rollback_last(Path(workspace))
+    if count == 0:
+        typer.echo("[rollback-update] no snapshot found — nothing to restore")
+        raise typer.Exit(1)
+    typer.echo(f"[rollback-update] restored {count} file(s) from the last snapshot")
+
+
 @app.command()
 def version() -> None:
     """Show versions and package update guidance."""
     from job_hunter.config.loader import package_version
+    from job_hunter.update.versions import cached_status
     from job_hunter.workspace.manifest import find_workspace_root, read_manifest
 
     typer.echo(f"job-hunter {package_version()}")
@@ -147,6 +185,10 @@ def version() -> None:
             typer.echo(f"workspace (no manifest)  ({workspace})")
     else:
         typer.echo("workspace not found (run 'job-hunter init' to create one)")
+
+    status = cached_status()  # cache-only — never makes a network call here
+    if status["update_available"]:
+        typer.echo(f"\n[update] v{status['latest']} available — one-click update in `job-hunter dash`, or:")
 
     typer.echo(
         "\nUpdate flow:\n"

--- a/job_hunter/shortcut.py
+++ b/job_hunter/shortcut.py
@@ -1,0 +1,118 @@
+"""First-run desktop shortcut registration, opt-out.
+
+Called from `job-hunter dash` on first run — click-icon-to-launch is the daily-use
+goal; a terminal is only needed once. State (whether a shortcut was created, or the
+user opted out) lives in launcher.platform_config_dir(), not the workspace — this is
+OS app state, not a user choice about job search behavior, so it doesn't belong in
+config/job_hunter.yml (see the OWNERSHIP PRINCIPLE in AGENTS.md).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_STATE_FILENAME = "app_state.json"
+_DESKTOP_ENTRY = (
+    "[Desktop Entry]\n"
+    "Type=Application\n"
+    "Name=Job Hunter\n"
+    "Comment=Autonomous job search assistant\n"
+    "Exec={exe} dash\n"
+    "Icon=job-hunter\n"
+    "Terminal=false\n"
+    "Categories=Office;Utility;\n"
+)
+
+
+def _state_path() -> Path:
+    from job_hunter.launcher import platform_config_dir
+
+    return platform_config_dir() / _STATE_FILENAME
+
+
+def _read_state() -> dict[str, Any]:
+    path = _state_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_state(state: dict[str, Any]) -> None:
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def record_opt_out() -> None:
+    """`job-hunter dash --no-shortcut` calls this so future launches never create one."""
+    state = _read_state()
+    state["shortcut_optout"] = True
+    _write_state(state)
+
+
+def _create_windows_shortcut() -> bool:
+    """Start Menu .lnk via WScript.Shell, run through PowerShell — no new dependency."""
+    exe = shutil.which("job-hunter")
+    if not exe:
+        return False
+    start_menu_base = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+    start_menu = Path(start_menu_base) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+    if not start_menu.is_dir():
+        return False
+    lnk_path = start_menu / "Job Hunter.lnk"
+    script = (
+        "$W = New-Object -ComObject WScript.Shell; "
+        f'$S = $W.CreateShortcut("{lnk_path}"); '
+        f'$S.TargetPath = "{exe}"; '
+        '$S.Arguments = "dash"; '
+        f'$S.WorkingDirectory = "{Path(exe).parent}"; '
+        "$S.Save()"
+    )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-Command", script], capture_output=True, text=True, check=False
+    )
+    return result.returncode == 0
+
+
+def _create_linux_shortcut() -> bool:
+    """~/.local/share/applications/job-hunter.desktop — mirrors packaging/linux/job-hunter.desktop."""
+    exe = shutil.which("job-hunter") or "job-hunter"
+    apps_dir = Path.home() / ".local" / "share" / "applications"
+    apps_dir.mkdir(parents=True, exist_ok=True)
+    (apps_dir / "job-hunter.desktop").write_text(_DESKTOP_ENTRY.format(exe=exe), encoding="utf-8")
+    return True
+
+
+def ensure_desktop_shortcut() -> None:
+    """Create a desktop entry on first run, unless already created or opted out.
+
+    macOS is skipped — a native .app install already puts Job Hunter in
+    Applications/Launchpad; there's no separate shortcut to create for a
+    `pip`/`uv tool install`. Never raises — a failed shortcut is a shrug, not a
+    reason to block `dash` from opening.
+    """
+    state = _read_state()
+    if state.get("shortcut_optout") or state.get("shortcut_created"):
+        return
+    try:
+        if sys.platform == "win32":
+            created = _create_windows_shortcut()
+        elif sys.platform.startswith("linux"):
+            created = _create_linux_shortcut()
+        else:
+            created = False
+    except OSError:
+        created = False
+    if created:
+        state["shortcut_created"] = True
+        _write_state(state)

--- a/job_hunter/templates/workspace/SETUP.md
+++ b/job_hunter/templates/workspace/SETUP.md
@@ -24,18 +24,41 @@ later by changing `mode:` in `config/job_hunter.yml`.
 
 ## 3. Requirements
 
+**Windows and macOS:** none — the installer below bundles everything Job Hunter needs.
+
+**Linux, or if you prefer a terminal on any OS:**
+
 | Tool | Needed for | Get it |
 |---|---|---|
-| Python 3.12 or 3.13 | Both modes (there's no packaged installer yet — install still runs through a terminal once) | [python.org/downloads](https://www.python.org/downloads/) |
+| Python 3.12 or 3.13 | Both modes | [python.org/downloads](https://www.python.org/downloads/) |
 | [uv](https://docs.astral.sh/uv/) | Both modes (recommended installer) | Installed in step 4 below |
-| An LLM API key (Anthropic, OpenAI, or Google) | LLM API mode only | See [SETUP_LLM_API.md](SETUP_LLM_API.md) |
-| VS Code + Claude Code or Codex extension | Agent mode's daily review/tailoring only — not needed for setup, and not needed at all in LLM API mode | [code.visualstudio.com](https://code.visualstudio.com/) |
 
 Python 3.14 and Python 3.11 or older are not supported.
 
+An LLM API key (Anthropic, OpenAI, or Google) is needed for LLM API mode
+only — see [SETUP_LLM_API.md](SETUP_LLM_API.md). VS Code with the Claude
+Code or Codex extension is needed for Agent mode's daily review/tailoring
+only — not needed for setup, and not needed at all in LLM API mode.
+
 ## 4. Install Job Hunter
 
-Open a terminal and run:
+**Windows:** download `Job-Hunter-Setup-<version>.exe` from the
+[latest release](https://github.com/abdulrbasit/job-hunter/releases/latest),
+run it, and the dashboard opens automatically. It's unsigned, so Windows
+SmartScreen may warn on first run — choose "More info" → "Run anyway".
+
+**macOS:** download `Job-Hunter-<version>.pkg` from the
+[latest release](https://github.com/abdulrbasit/job-hunter/releases/latest)
+and run it. It's unsigned, so the first launch needs right-click (or
+Control-click) the app → **Open** → **Open**, instead of a normal double-click.
+
+**Linux, or a terminal on any OS:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/abdulrbasit/job-hunter/main/packaging/linux/install.sh | sh
+```
+
+or manually:
 
 ```bash
 python -m pip install uv
@@ -56,6 +79,10 @@ found", your terminal needs restarting after `update-shell`, or your
 Python Scripts folder isn't on `PATH`. See the troubleshooting sections in
 [SETUP_AGENT.md](SETUP_AGENT.md) or [SETUP_LLM_API.md](SETUP_LLM_API.md).
 
+**Updates:** once installed, open the dashboard (`job-hunter dash`) — when
+a new version is available, an "Update now" banner appears and handles the
+upgrade and restart for you. No terminal needed.
+
 ## 5. Create a workspace
 
 ```bash
@@ -73,6 +100,10 @@ steps printed.
 ```bash
 job-hunter dash
 ```
+
+The first time you run this, Job Hunter also adds a Start Menu shortcut
+(Windows) or applications-menu entry (Linux) so future launches don't need
+a terminal — click the icon instead. Pass `--no-shortcut` to skip this.
 
 A new workspace opens straight into a guided setup wizard: mode, job
 titles, region, languages/experience/exclusions — then a **Career

--- a/job_hunter/update/__init__.py
+++ b/job_hunter/update/__init__.py
@@ -1,0 +1,11 @@
+"""In-app update machinery: PyPI version check, upgrader detection, snapshot/rollback of
+system-owned workspace files, changelog lookup, and the detached self-update helper.
+
+Package-owned, read-only to the user — no new user-config surface. State this package
+writes (update-check cache, last-update result) lives in launcher.platform_config_dir(),
+not the workspace; snapshots live under outputs/state/ (already user-owned/regenerable
+per DATA_CONTRACT.md). May depend on config/ and workspace/; must not depend on ux/,
+cli/, or pipeline/ (ux/ depends on update/, not the reverse).
+"""
+
+from __future__ import annotations

--- a/job_hunter/update/changelog.py
+++ b/job_hunter/update/changelog.py
@@ -1,0 +1,18 @@
+"""GitHub release notes for the update dialog — lazy, offline-tolerant."""
+
+from __future__ import annotations
+
+_RELEASES_URL = "https://api.github.com/repos/abdulrbasit/job-hunter/releases/tags/v{version}"
+
+
+def github_release_notes(version: str, timeout: float = 3.0) -> str | None:
+    """Return the release body for vX.Y, or None if unavailable (offline, not yet released, etc.)."""
+    import requests
+
+    try:
+        response = requests.get(_RELEASES_URL.format(version=version), timeout=timeout)
+        if response.status_code != 200:
+            return None
+        return str(response.json().get("body") or "").strip() or None
+    except Exception:  # noqa: BLE001 — network/parsing failures must not crash the caller
+        return None

--- a/job_hunter/update/self_update.py
+++ b/job_hunter/update/self_update.py
@@ -1,0 +1,135 @@
+"""Runs out-of-process, spawned detached by ux/web/api.py::DashAPI.start_self_update right
+before the dashboard window closes: upgrades the installed package, refreshes workspace
+assets, and relaunches the dashboard. See start_self_update's docstring for why this can't
+happen in-process (Windows locks the running executable; every OS keeps old code loaded
+in memory).
+
+No explicit wait for the old process's pid to exit — cross-platform pid-liveness checks
+need OS-specific code (ctypes on Windows) for no real benefit here. What actually matters
+is whether the installed console-script is still locked by the exiting process; a short
+grace period plus retrying the upgrade command on failure observes that directly instead
+of inferring it from process state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from job_hunter.update.upgrader import Upgrader
+
+_GRACE_PERIOD_SECONDS = 2.0
+_UPGRADE_ATTEMPTS = 4
+_UPGRADE_RETRY_DELAY_SECONDS = 2.0
+_LAST_RESULT_FILENAME = "last_update.json"
+
+
+def _last_result_path() -> Path:
+    from job_hunter.launcher import platform_config_dir
+
+    return platform_config_dir() / _LAST_RESULT_FILENAME
+
+
+def read_last_result() -> dict[str, Any] | None:
+    """The previous self-update's outcome, for a post-restart toast. None if there isn't one."""
+    path = _last_result_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def clear_last_result() -> None:
+    path = _last_result_path()
+    if path.exists():
+        path.unlink()
+
+
+def _write_result(result: dict[str, Any]) -> None:
+    path = _last_result_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result), encoding="utf-8")
+
+
+def _run_upgrade(upgrader: Upgrader) -> tuple[bool, str]:
+    last_error = ""
+    for attempt in range(_UPGRADE_ATTEMPTS):
+        if attempt:
+            time.sleep(_UPGRADE_RETRY_DELAY_SECONDS)
+        proc = subprocess.run(upgrader.command, capture_output=True, text=True, check=False)
+        if proc.returncode == 0:
+            return True, proc.stdout.strip()
+        last_error = proc.stderr.strip() or proc.stdout.strip()
+    return False, last_error
+
+
+def detached_popen_kwargs(cwd: Path, env: dict[str, str] | None = None) -> dict[str, Any]:
+    """subprocess.Popen kwargs to spawn a process that outlives its parent, on any OS.
+
+    Shared by self-update's own relaunch below and by DashAPI.start_self_update, which
+    spawns this module's CLI entry point (`job-hunter internal self-update`) the same way.
+    """
+    kwargs: dict[str, Any] = {"cwd": str(cwd), "env": env if env is not None else os.environ}
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.DETACHED_PROCESS
+    else:
+        kwargs["start_new_session"] = True
+    return kwargs
+
+
+def _relaunch_dashboard(workspace: Path) -> None:
+    env = {**os.environ, "JOB_HUNTER_ROOT": str(workspace)}
+    subprocess.Popen(["job-hunter", "dash"], **detached_popen_kwargs(workspace, env))
+
+
+def run_self_update(workspace: Path, upgrader: Upgrader, *, from_version: str) -> dict[str, Any]:
+    """Upgrade the installed package, refresh workspace assets, relaunch the dashboard.
+
+    Meant to be invoked as `job-hunter internal self-update` — see
+    cli/commands/update.py::self_update_cmd and DashAPI.start_self_update.
+    """
+    time.sleep(_GRACE_PERIOD_SECONDS)
+
+    ok, message = _run_upgrade(upgrader)
+    if not ok:
+        result = {
+            "ok": False,
+            "stage": "upgrade",
+            "from": from_version,
+            "message": message or "Package upgrade failed.",
+            "fallback_command": " ".join(upgrader.command),
+        }
+        _write_result(result)
+        return result
+
+    workspace_proc = subprocess.run(
+        ["job-hunter", "update", "--yes", "--workspace", str(workspace)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if workspace_proc.returncode != 0:
+        result = {
+            "ok": False,
+            "stage": "workspace_update",
+            "from": from_version,
+            "message": workspace_proc.stderr.strip() or "Package upgraded, but the workspace update failed.",
+            "fallback_command": "job-hunter update --yes",
+        }
+        _write_result(result)
+        return result
+
+    from job_hunter.update.versions import installed_version
+
+    result = {"ok": True, "stage": "done", "from": from_version, "to": installed_version()}
+    _write_result(result)
+    _relaunch_dashboard(workspace)
+    return result

--- a/job_hunter/update/snapshot.py
+++ b/job_hunter/update/snapshot.py
@@ -1,0 +1,66 @@
+"""Snapshot/rollback for system-owned workspace files before an update overwrites them.
+
+Only the single most-recent snapshot is kept — one-click rollback undoes the last
+update, not arbitrary history. outputs/ is already user-owned/regenerable per
+DATA_CONTRACT.md, so storing the snapshot there needs no new ownership carve-out.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from job_hunter.workspace.assets import UPDATE_ASSETS
+from job_hunter.workspace.safety import classify_path
+
+_SNAPSHOT_DIR_PARTS = ("outputs", "state", "update_snapshot")
+# Deliberately not workspace.safety.SYSTEM_LAYER_PREFIXES — that list also includes
+# job_hunter/, tests/, docs/ for the dev-repo checkout case, which would make a snapshot
+# walk the entire package source tree if the workspace root happens to be the repo itself.
+_MANAGED_DIRS = (".claude/skills", ".agents/skills", ".github")
+
+
+def _snapshot_root(workspace: Path) -> Path:
+    return workspace.joinpath(*_SNAPSHOT_DIR_PARTS)
+
+
+def _iter_snapshot_targets(workspace: Path) -> list[Path]:
+    """Every file update_workspace_assets()/update_skills()/update_workflows() may overwrite."""
+    targets = [workspace / rel for rel in UPDATE_ASSETS]
+    for rel_dir in _MANAGED_DIRS:
+        base = workspace / rel_dir
+        if base.is_dir():
+            targets.extend(p for p in base.rglob("*") if p.is_file())
+    return [t for t in targets if t.is_file() and classify_path(t.relative_to(workspace)) == "system"]
+
+
+def snapshot_system_files(workspace: Path) -> int:
+    """Copy current system-owned files into the snapshot dir, replacing any prior snapshot."""
+    workspace = workspace.resolve()
+    root = _snapshot_root(workspace)
+    if root.exists():
+        shutil.rmtree(root)
+    count = 0
+    for src in _iter_snapshot_targets(workspace):
+        dest = root / src.relative_to(workspace)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        count += 1
+    return count
+
+
+def rollback_last(workspace: Path) -> int:
+    """Restore the most recent snapshot over the workspace. Returns files restored, 0 if none exists."""
+    workspace = workspace.resolve()
+    root = _snapshot_root(workspace)
+    if not root.is_dir():
+        return 0
+    count = 0
+    for src in root.rglob("*"):
+        if not src.is_file():
+            continue
+        dest = workspace / src.relative_to(root)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        count += 1
+    return count

--- a/job_hunter/update/upgrader.py
+++ b/job_hunter/update/upgrader.py
@@ -1,0 +1,39 @@
+"""Detect which tool manages the installed job-hunter-kit package, for one-click upgrade."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+_PACKAGE = "job-hunter-kit"
+
+
+@dataclass(frozen=True)
+class Upgrader:
+    tool: str
+    command: list[str]
+
+
+def _tool_manages_package(tool: str, list_args: list[str]) -> bool:
+    if not shutil.which(tool):
+        return False
+    result = subprocess.run([tool, *list_args], capture_output=True, text=True, check=False)  # noqa: S603
+    return result.returncode == 0 and _PACKAGE in result.stdout
+
+
+def detect_upgrader() -> Upgrader | None:
+    """Return the upgrade command for however job-hunter-kit was installed.
+
+    None means undetectable — a PyInstaller-built binary (packaging/) has no bundled
+    python/pip to upgrade in place; the caller should fall back to a copyable command
+    or "download the latest installer" messaging.
+    """
+    if getattr(sys, "frozen", False):
+        return None
+    if _tool_manages_package("uv", ["tool", "list"]):
+        return Upgrader("uv", ["uv", "tool", "upgrade", _PACKAGE])
+    if _tool_manages_package("pipx", ["list"]):
+        return Upgrader("pipx", ["pipx", "upgrade", _PACKAGE])
+    return Upgrader("pip", [sys.executable, "-m", "pip", "install", "--upgrade", _PACKAGE])

--- a/job_hunter/update/versions.py
+++ b/job_hunter/update/versions.py
@@ -1,0 +1,100 @@
+"""PyPI version check for job-hunter-kit: cached, offline-tolerant, never blocks startup.
+
+cached_status() is the only call on the dashboard's hot path — it reads the on-disk
+cache and does no network I/O. refresh_cache() does the actual PyPI lookup and is meant
+to be run off the calling thread (see ux/web/api.py::DashAPI.get_update_status).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+_PYPI_URL = "https://pypi.org/pypi/job-hunter-kit/json"
+_CACHE_TTL_SECONDS = 24 * 60 * 60
+_CACHE_FILENAME = "update_check.json"
+
+
+def installed_version() -> str:
+    from job_hunter.config.loader import package_version
+
+    return package_version()
+
+
+def _version_tuple(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", text)) or (0,)
+
+
+def is_newer(latest: str, installed: str) -> bool:
+    """True if latest > installed, comparing dotted numeric parts (e.g. "0.26" > "0.25")."""
+    return _version_tuple(latest) > _version_tuple(installed)
+
+
+def latest_pypi_version(timeout: float = 3.0) -> str | None:
+    """Query PyPI for the latest published version. Returns None on any failure — never raises."""
+    import requests
+
+    try:
+        response = requests.get(_PYPI_URL, timeout=timeout)
+        response.raise_for_status()
+        return str(response.json()["info"]["version"])
+    except Exception:  # noqa: BLE001 — network/parsing failures must not crash the caller
+        return None
+
+
+def _cache_path() -> Path:
+    from job_hunter.launcher import platform_config_dir
+
+    return platform_config_dir() / _CACHE_FILENAME
+
+
+def _read_cache() -> dict[str, Any] | None:
+    path = _cache_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def cached_status() -> dict[str, Any]:
+    """Return the last-known update status from cache without any network call."""
+    installed = installed_version()
+    data = _read_cache() or {}
+    latest = data.get("latest")
+    return {
+        "installed": installed,
+        "latest": latest,
+        "update_available": bool(latest) and is_newer(latest, installed),
+        "checked_at": data.get("checked_at"),
+    }
+
+
+def cache_is_stale() -> bool:
+    data = _read_cache()
+    if data is None:
+        return True
+    checked_at = data.get("checked_at")
+    if not isinstance(checked_at, int | float):
+        return True
+    return (time.time() - checked_at) > _CACHE_TTL_SECONDS
+
+
+def refresh_cache() -> dict[str, Any]:
+    """Query PyPI and persist the result. Safe to call from a background thread.
+
+    On a failed lookup (offline), the cache is left untouched rather than stamped with
+    a "checked just now" timestamp — that way the next check retries immediately instead
+    of waiting out the full 24h TTL while offline.
+    """
+    latest = latest_pypi_version()
+    if latest is not None:
+        path = _cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"latest": latest, "checked_at": time.time()}), encoding="utf-8")
+    return cached_status()

--- a/job_hunter/update/versions.py
+++ b/job_hunter/update/versions.py
@@ -75,11 +75,12 @@ def cached_status() -> dict[str, Any]:
     }
 
 
-def cache_is_stale() -> bool:
-    data = _read_cache()
-    if data is None:
-        return True
-    checked_at = data.get("checked_at")
+def cache_is_stale(checked_at: float | None = None) -> bool:
+    """Whether the cache needs a refresh. Takes cached_status()'s "checked_at" — callers
+    that already hold a status dict from this launch avoid a second cache-file read."""
+    if checked_at is None:
+        data = _read_cache()
+        checked_at = data.get("checked_at") if data else None
     if not isinstance(checked_at, int | float):
         return True
     return (time.time() - checked_at) > _CACHE_TTL_SECONDS

--- a/job_hunter/ux/web/api.py
+++ b/job_hunter/ux/web/api.py
@@ -508,7 +508,7 @@ class DashAPI:
         from job_hunter.update import versions
 
         status = versions.cached_status()
-        if versions.cache_is_stale():
+        if versions.cache_is_stale(status["checked_at"]):
             threading.Thread(target=versions.refresh_cache, daemon=True).start()
         return {"ok": True, **status}
 

--- a/job_hunter/ux/web/api.py
+++ b/job_hunter/ux/web/api.py
@@ -501,6 +501,91 @@ class DashAPI:
             "warnings": [],
         }
 
+    def get_update_status(self) -> dict[str, Any]:
+        """Non-blocking: returns the cached PyPI version-check result immediately, kicking
+        off a background refresh if the cache is stale (24h TTL) or missing. Never delays
+        dashboard startup — see update/versions.py."""
+        from job_hunter.update import versions
+
+        status = versions.cached_status()
+        if versions.cache_is_stale():
+            threading.Thread(target=versions.refresh_cache, daemon=True).start()
+        return {"ok": True, **status}
+
+    def get_update_changelog(self, version: str) -> dict[str, Any]:
+        from job_hunter.update.changelog import github_release_notes
+
+        return {"ok": True, "version": version, "notes": github_release_notes(version)}
+
+    def get_last_update_result(self) -> dict[str, Any]:
+        """One-shot: the previous self-update's outcome, for a post-restart toast. Consumes
+        it — a second call won't re-show the same toast."""
+        from job_hunter.update.self_update import clear_last_result, read_last_result
+
+        result = read_last_result()
+        clear_last_result()
+        if result is None:
+            return {"ok": True, "status": "none"}
+        return {"ok": True, "status": "done", **result}
+
+    def start_self_update(self) -> dict[str, Any]:
+        """Snapshots system-owned workspace files, spawns a detached helper process that
+        upgrades the installed package once this window closes, then closes the window.
+        The helper (`job-hunter internal self-update`) runs the upgrade, refreshes
+        workspace assets, and relaunches the dashboard — see update/self_update.py for why
+        this can't happen in-process (Windows locks the running executable; every OS keeps
+        old code loaded in memory)."""
+        with self._hunt_lock:
+            if self._hunt_running:
+                return {
+                    "ok": False,
+                    "status": "running",
+                    "error": "A hunt is running — try updating after it finishes.",
+                }
+
+        from job_hunter.update.snapshot import snapshot_system_files
+        from job_hunter.update.upgrader import detect_upgrader
+        from job_hunter.update.versions import installed_version
+
+        upgrader = detect_upgrader()
+        if upgrader is None:
+            return {
+                "ok": False,
+                "error": "Could not detect how job-hunter-kit was installed.",
+                "fallback_command": "pip install --upgrade job-hunter-kit",
+            }
+
+        snapshot_system_files(self._root)
+
+        from job_hunter.update.self_update import detached_popen_kwargs
+
+        subprocess.Popen(  # noqa: S603, S607
+            [
+                "job-hunter",
+                "internal",
+                "self-update",
+                "--workspace",
+                str(self._root),
+                "--from-version",
+                installed_version(),
+            ],
+            **detached_popen_kwargs(self._root),
+        )
+        threading.Thread(target=self._close_window_soon, daemon=True).start()
+        return {"ok": True, "status": "restarting"}
+
+    @staticmethod
+    def _close_window_soon() -> None:
+        """Give the pending start_self_update() JS-bridge call a moment to return before
+        the window disappears out from under it."""
+        import time
+
+        import webview
+
+        time.sleep(0.5)
+        if webview.windows:
+            webview.windows[0].destroy()
+
     def get_api_key_status(self) -> dict[str, Any]:
         from job_hunter.config.secrets import get_secret
         from job_hunter.core.utils import read_yaml

--- a/job_hunter/ux/web/dashboard.css
+++ b/job_hunter/ux/web/dashboard.css
@@ -237,6 +237,9 @@ main {
 .pager { display:flex; align-items:center; justify-content:flex-end; gap:10px; padding:10px 14px; color:var(--text-muted); font-size:12px; }
 .onboarding-banner { margin:12px 20px 0; padding:10px 14px; border:1px solid var(--amber); border-radius:8px; background:rgba(245,158,11,.08); font-size:13px; }
 .onboarding-progress { font-weight:600; margin-bottom:6px; }
+.update-banner { margin:12px 20px 0; padding:10px 14px; border:1px solid var(--blue); border-radius:8px; background:rgba(31,111,235,.08); font-size:13px; }
+.update-banner a { color: var(--blue-fg); font-weight:600; }
+.update-banner code { background: var(--surface2); padding:1px 5px; border-radius:4px; }
 .onboarding-checklist { list-style:none; display:flex; flex-direction:column; gap:4px; }
 .onboarding-item { display:flex; align-items:center; gap:8px; font-size:13px; }
 .onboarding-item .oi-mark { width:16px; text-align:center; color: var(--text-muted); }

--- a/job_hunter/ux/web/dashboard.html
+++ b/job_hunter/ux/web/dashboard.html
@@ -66,6 +66,7 @@
     <button class="btn" id="refresh-btn">↺ Refresh</button>
   </div>
   <div class="onboarding-banner" id="onboarding-banner" style="display:none"></div>
+  <div class="update-banner" id="update-banner" style="display:none"></div>
 
   <!-- Today view: fresh matches ranked by fit, one-click triage -->
   <section id="view-today" class="view active">

--- a/job_hunter/ux/web/dashboard.js
+++ b/job_hunter/ux/web/dashboard.js
@@ -162,6 +162,55 @@ async function initAll() {
   await loadApplicationStreak();
   await refreshAll();
   runSync({ silent: true }); // auto-sync on open — merge is lossless by construction, safe unattended
+  checkForUpdate();          // non-blocking — cached read, background PyPI refresh if stale
+  checkLastUpdateResult();   // non-blocking — one-shot toast after a self-update restart
+}
+
+// ── Update banner — PyPI version check, one-click upgrade + restart ──
+async function checkForUpdate() {
+  try {
+    renderUpdateBanner(await window.pywebview.api.get_update_status());
+  } catch(_) { /* offline or check failed — banner just stays hidden */ }
+}
+
+function renderUpdateBanner(status) {
+  const banner = document.getElementById('update-banner');
+  if (!status || !status.ok || !status.update_available) { banner.style.display = 'none'; return; }
+  banner.innerHTML = `v${esc(status.latest)} available — <a href="#" id="update-now-link">Update now</a>`;
+  document.getElementById('update-now-link').addEventListener('click', (e) => {
+    e.preventDefault();
+    startUpdate(status.latest);
+  });
+  banner.style.display = '';
+}
+
+async function startUpdate(version) {
+  let notes = '';
+  try {
+    const changelog = await window.pywebview.api.get_update_changelog(version);
+    if (changelog.ok && changelog.notes) notes = `\n\n${changelog.notes}`;
+  } catch(_) {}
+  if (!confirm(`Update job-hunter-kit to v${version}? The app will close and reopen automatically.${notes}`)) return;
+
+  const banner = document.getElementById('update-banner');
+  const result = await window.pywebview.api.start_self_update();
+  if (!result.ok) {
+    banner.innerHTML = result.fallback_command
+      ? `Could not update automatically. Run this in a terminal, then reopen the app: <code>${esc(result.fallback_command)}</code>`
+      : esc(result.error || 'Could not start the update.');
+    banner.style.display = '';
+    return;
+  }
+  banner.textContent = 'Updating — the app will restart shortly…';
+  banner.style.display = '';
+}
+
+async function checkLastUpdateResult() {
+  try {
+    const result = await window.pywebview.api.get_last_update_result();
+    if (result.status !== 'done') return;
+    showToast(result.ok ? `✓ Updated to v${result.to}` : (result.message || 'The last update did not complete.'));
+  } catch(_) {}
 }
 
 // Only the fields a first hunt actually needs gate the Get Started landing — story bank,

--- a/job_hunter/workspace/assets.py
+++ b/job_hunter/workspace/assets.py
@@ -50,6 +50,9 @@ _UPDATE_ASSETS = (
     "SETUP_LLM_API.md",
     "config/schemas/job_hunter.schema.json",
 )
+# Public alias — job_hunter/update/snapshot.py needs the same list to know what an
+# update is about to overwrite, without reaching into a private module attribute.
+UPDATE_ASSETS = _UPDATE_ASSETS
 _README_BLOCKS = (
     ("<!-- JOBS_STATS_START -->", "<!-- JOBS_STATS_END -->"),
     ("<!-- JOBS_TABLE_START -->", "<!-- JOBS_TABLE_END -->"),

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# One-line bootstrap install for job-hunter-kit on Linux: installs uv if missing,
+# installs job-hunter-kit as a uv tool, registers a .desktop launcher, and opens
+# the dashboard. Linux keeps `uv tool install` as the primary install path (Layer 2
+# native installers are Windows/macOS-only) — this script just removes the remaining
+# manual steps.
+#
+#   curl -fsSL https://raw.githubusercontent.com/abdulrbasit/job-hunter/main/packaging/linux/install.sh | sh
+set -euo pipefail
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "Installing job-hunter-kit..."
+uv tool install job-hunter-kit
+uv tool update-shell
+
+BIN="$(command -v job-hunter || echo "$HOME/.local/bin/job-hunter")"
+APPS_DIR="$HOME/.local/share/applications"
+mkdir -p "$APPS_DIR"
+cat > "$APPS_DIR/job-hunter.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Job Hunter
+Comment=Autonomous job search assistant
+Exec=$BIN dash
+Icon=job-hunter
+Terminal=false
+Categories=Office;Utility;
+EOF
+
+echo "Installed. Opening the dashboard..."
+nohup "$BIN" dash >/dev/null 2>&1 &
+disown
+echo "Job Hunter is starting. Next time, launch it from your applications menu or run: job-hunter dash"

--- a/packaging/linux/job-hunter.spec
+++ b/packaging/linux/job-hunter.spec
@@ -31,7 +31,14 @@ datas = [
     (str(root / "job_hunter" / "ux" / "web" / "dashboard.js"), "job_hunter/ux/web"),
     (str(root / "job_hunter" / "catalog" / "countries.json"), "job_hunter/catalog"),
     (str(root / "job_hunter" / "catalog" / "filters.json"), "job_hunter/catalog"),
-    (str(root / "job_hunter" / "catalog" / "companies.json"), "job_hunter/catalog"),
+    (str(root / "job_hunter" / "catalog" / "experience_levels.json"), "job_hunter/catalog"),
+    (str(root / "job_hunter" / "catalog" / "job_titles.json"), "job_hunter/catalog"),
+    # Company catalog moved from catalog/companies.json to a runtime store seeded from
+    # per-country jsonl files; location data lives in its own resource tree. Both are
+    # required package-data (pyproject.toml's [tool.setuptools.package-data]) that the
+    # original catalog/companies.json-only datas list predates and never picked up.
+    *tree(root / "job_hunter" / "companies" / "data", "job_hunter/companies/data"),
+    *tree(root / "job_hunter" / "locations" / "data", "job_hunter/locations/data"),
     *tree(root / "job_hunter" / "templates", "job_hunter/templates"),
 ]
 hiddenimports = [

--- a/packaging/macos/build_pkg.sh
+++ b/packaging/macos/build_pkg.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Wraps the PyInstaller-built "dist/Job Hunter.app" (packaging/macos/job-hunter.spec)
+# into an unsigned .pkg installer via pkgbuild. Unbuilt/untested in this repo's dev
+# environment — no macOS hardware available (same limitation docs/macos-packaging.md
+# already documents for the .app spike itself). Run this on a real Mac after building
+# the .app; signing/notarization are separate follow-up steps, also documented there.
+set -euo pipefail
+
+VERSION="${1:?Usage: build_pkg.sh <version>}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APP="$ROOT/dist/Job Hunter.app"
+OUT_DIR="$ROOT/dist-installer"
+
+if [ ! -d "$APP" ]; then
+  echo "error: $APP not found — build it first:" >&2
+  echo "  uv run --with pyinstaller pyinstaller --noconfirm --clean packaging/macos/job-hunter.spec" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+pkgbuild \
+  --install-location /Applications \
+  --component "$APP" \
+  --version "$VERSION" \
+  --identifier com.jobhunterkit.jobhunter \
+  "$OUT_DIR/Job-Hunter-$VERSION.pkg"
+
+echo "Unsigned package written to $OUT_DIR/Job-Hunter-$VERSION.pkg"
+echo "Unsigned — first launch needs right-click > Open. See docs/macos-packaging.md for signing/notarization."

--- a/packaging/macos/job-hunter.spec
+++ b/packaging/macos/job-hunter.spec
@@ -31,7 +31,14 @@ datas = [
     (str(root / "job_hunter" / "ux" / "web" / "dashboard.js"), "job_hunter/ux/web"),
     (str(root / "job_hunter" / "catalog" / "countries.json"), "job_hunter/catalog"),
     (str(root / "job_hunter" / "catalog" / "filters.json"), "job_hunter/catalog"),
-    (str(root / "job_hunter" / "catalog" / "companies.json"), "job_hunter/catalog"),
+    (str(root / "job_hunter" / "catalog" / "experience_levels.json"), "job_hunter/catalog"),
+    (str(root / "job_hunter" / "catalog" / "job_titles.json"), "job_hunter/catalog"),
+    # Company catalog moved from catalog/companies.json to a runtime store seeded from
+    # per-country jsonl files; location data lives in its own resource tree. Both are
+    # required package-data (pyproject.toml's [tool.setuptools.package-data]) that the
+    # original catalog/companies.json-only datas list predates and never picked up.
+    *tree(root / "job_hunter" / "companies" / "data", "job_hunter/companies/data"),
+    *tree(root / "job_hunter" / "locations" / "data", "job_hunter/locations/data"),
     *tree(root / "job_hunter" / "templates", "job_hunter/templates"),
 ]
 hiddenimports = [

--- a/packaging/windows/job-hunter.iss
+++ b/packaging/windows/job-hunter.iss
@@ -1,0 +1,51 @@
+; Wraps the PyInstaller onedir bundle (dist/job-hunter/, from job-hunter.spec) into a
+; Windows installer with a Start Menu entry. Authored against Inno Setup 6's documented
+; syntax but not compiled in this environment (no Inno Setup toolchain installed here) —
+; validate with `iscc` on a Windows machine with Inno Setup 6 before shipping.
+;
+; Build order:
+;   1. uv run --with pyinstaller pyinstaller --noconfirm --clean packaging/windows/job-hunter.spec
+;   2. iscc packaging/windows/job-hunter.iss /DAppVersion=0.25
+;
+; AppVersion is passed via /D from CI (release.yml reads it from pyproject.toml) so this
+; file never needs hand-editing to release a new version.
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+
+[Setup]
+AppId={{9F6E9B7A-5C2E-4B8E-9B0E-6A1E7C3E9B7A}
+AppName=Job Hunter
+AppVersion={#AppVersion}
+AppPublisher=Abdul Basit
+AppPublisherURL=https://github.com/abdulrbasit/job-hunter
+DefaultDirName={autopf}\Job Hunter
+DefaultGroupName=Job Hunter
+DisableProgramGroupPage=yes
+OutputDir=..\..\dist-installer
+OutputBaseFilename=Job-Hunter-Setup-{#AppVersion}
+Compression=lzma2
+SolidCompression=yes
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+WizardStyle=modern
+; Unsigned build — no SignTool directive here. Windows SmartScreen will warn on first
+; run until a code-signing certificate is available; see docs/windows-packaging.md.
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Files]
+Source: "..\..\dist\job-hunter\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\Job Hunter"; Filename: "{app}\job-hunter.exe"; Parameters: "dash"; WorkingDir: "{app}"
+Name: "{group}\Uninstall Job Hunter"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\Job Hunter"; Filename: "{app}\job-hunter.exe"; Parameters: "dash"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\job-hunter.exe"; Parameters: "dash"; Description: "Launch Job Hunter"; Flags: nowait postinstall skipifsilent

--- a/packaging/windows/job-hunter.spec
+++ b/packaging/windows/job-hunter.spec
@@ -25,7 +25,14 @@ datas = [
     (str(root / "job_hunter" / "ux" / "web" / "dashboard.js"), "job_hunter/ux/web"),
     (str(root / "job_hunter" / "catalog" / "countries.json"), "job_hunter/catalog"),
     (str(root / "job_hunter" / "catalog" / "filters.json"), "job_hunter/catalog"),
-    (str(root / "job_hunter" / "catalog" / "companies.json"), "job_hunter/catalog"),
+    (str(root / "job_hunter" / "catalog" / "experience_levels.json"), "job_hunter/catalog"),
+    (str(root / "job_hunter" / "catalog" / "job_titles.json"), "job_hunter/catalog"),
+    # Company catalog moved from catalog/companies.json to a runtime store seeded from
+    # per-country jsonl files; location data lives in its own resource tree. Both are
+    # required package-data (pyproject.toml's [tool.setuptools.package-data]) that the
+    # original catalog/companies.json-only datas list predates and never picked up.
+    *tree(root / "job_hunter" / "companies" / "data", "job_hunter/companies/data"),
+    *tree(root / "job_hunter" / "locations" / "data", "job_hunter/locations/data"),
     *tree(root / "job_hunter" / "templates", "job_hunter/templates"),
 ]
 hiddenimports = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,9 @@ ignore = ["E501", "S101"]
 # Other subprocess calls in this file use inline noqa; this one is file-level because ruff
 # anchors the diagnostic to the multi-line argv list, not the subprocess.Popen(...) line.
 "job_hunter/ux/web/api.py" = ["S607"]
+# S603/S607: shortcut.py intentionally shells out to `powershell` by literal argv to
+# create a Start Menu shortcut.
+"job_hunter/shortcut.py" = ["S603", "S607"]
 # C901 ignores below: verified against `ruff check --select C901` with the ignore removed (Phase 3,
 # 2026-07-01) — every remaining entry still fires without it. Re-verify before trusting this list stale;
 # it drifts as functions are refactored. Phase 0 backlog tracks decomposing these, not silencing them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,14 @@ ignore = ["E501", "S101"]
 # finalize allowlist — the pure core shared by `job-hunter finalize`, `internal
 # finalize-run`, and the dashboard Finalize button.
 "job_hunter/workspace/finalize.py" = ["S603", "S607"]
+# S603/S607: self_update.py intentionally shells out to the detected upgrader (uv/pipx/pip)
+# and to `job-hunter update`/`job-hunter dash` by literal argv — the detached helper process
+# spawned by the dashboard's one-click update button.
+"job_hunter/update/self_update.py" = ["S603", "S607"]
+# S603/S607: DashAPI.start_self_update spawns the detached self-update helper by literal argv.
+# Other subprocess calls in this file use inline noqa; this one is file-level because ruff
+# anchors the diagnostic to the multi-line argv list, not the subprocess.Popen(...) line.
+"job_hunter/ux/web/api.py" = ["S607"]
 # C901 ignores below: verified against `ruff check --select C901` with the ignore removed (Phase 3,
 # 2026-07-01) — every remaining entry still fires without it. Re-verify before trusting this list stale;
 # it drifts as functions are refactored. Phase 0 backlog tracks decomposing these, not silencing them.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,7 +125,7 @@ def test_release_workflow_publishes_current_release_commit() -> None:
     assert set(triggers) == {"workflow_dispatch"}
 
     jobs = workflow["jobs"]
-    assert set(jobs) == {"release"}
+    assert set(jobs) == {"verify", "build-installers", "release"}
     text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
     assert "git tag" in text
     assert "git push origin" in text

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -1,0 +1,104 @@
+"""Tests for job_hunter/shortcut.py — first-run desktop shortcut, opt-out."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from job_hunter import shortcut
+
+
+@pytest.fixture(autouse=True)
+def _isolated_platform_config_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+
+
+def _proc(returncode: int) -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    return result
+
+
+def test_record_opt_out_then_ensure_shortcut_is_a_no_op() -> None:
+    shortcut.record_opt_out()
+
+    with patch("shutil.which", return_value="/usr/bin/job-hunter") as mock_which:
+        shortcut.ensure_desktop_shortcut()
+
+    mock_which.assert_not_called()  # short-circuited before touching the OS at all
+
+
+def test_ensure_desktop_shortcut_creates_linux_desktop_entry(tmp_path: Path) -> None:
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("shutil.which", return_value="/usr/bin/job-hunter"),
+        patch.object(Path, "home", return_value=tmp_path),
+    ):
+        shortcut.ensure_desktop_shortcut()
+
+    entry = tmp_path / ".local" / "share" / "applications" / "job-hunter.desktop"
+    assert entry.exists()
+    assert "Exec=/usr/bin/job-hunter dash" in entry.read_text(encoding="utf-8")
+
+
+def test_ensure_desktop_shortcut_is_idempotent_on_linux(tmp_path: Path) -> None:
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("shutil.which", return_value="/usr/bin/job-hunter") as mock_which,
+        patch.object(Path, "home", return_value=tmp_path),
+    ):
+        shortcut.ensure_desktop_shortcut()
+        shortcut.ensure_desktop_shortcut()
+
+    assert mock_which.call_count == 1  # second call short-circuits on shortcut_created
+
+
+def test_ensure_desktop_shortcut_creates_windows_lnk_via_powershell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    start_menu = tmp_path / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+    start_menu.mkdir(parents=True)
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    with (
+        patch.object(sys, "platform", "win32"),
+        patch("shutil.which", return_value="C:\\job-hunter.exe"),
+        patch("subprocess.run", return_value=_proc(0)) as mock_run,
+    ):
+        shortcut.ensure_desktop_shortcut()
+
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0][0] == "powershell"
+
+
+def test_ensure_desktop_shortcut_records_nothing_when_creation_fails() -> None:
+    # APPDATA (from the autouse fixture) has no Start Menu\Programs dir under it, so
+    # _create_windows_shortcut returns False without ever calling subprocess.
+    with (
+        patch.object(sys, "platform", "win32"),
+        patch("shutil.which", return_value="C:\\job-hunter.exe"),
+        patch("subprocess.run") as mock_run,
+    ):
+        shortcut.ensure_desktop_shortcut()
+
+    mock_run.assert_not_called()
+    assert shortcut._read_state().get("shortcut_created") is not True
+
+
+def test_ensure_desktop_shortcut_is_noop_on_macos() -> None:
+    with patch.object(sys, "platform", "darwin"), patch("shutil.which") as mock_which:
+        shortcut.ensure_desktop_shortcut()
+
+    mock_which.assert_not_called()
+
+
+def test_ensure_desktop_shortcut_swallows_oserror(tmp_path: Path) -> None:
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("shutil.which", side_effect=OSError("boom")),
+    ):
+        shortcut.ensure_desktop_shortcut()  # must not raise

--- a/tests/test_update_self_update.py
+++ b/tests/test_update_self_update.py
@@ -1,0 +1,101 @@
+"""Tests for job_hunter/update/self_update.py — the detached upgrade-and-relaunch helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from job_hunter.update import self_update
+from job_hunter.update.upgrader import Upgrader
+
+
+@pytest.fixture(autouse=True)
+def _isolated_platform_config_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep() -> None:
+    with patch("time.sleep"):
+        yield
+
+
+def _proc(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def test_run_self_update_success_writes_result_and_relaunches(tmp_path: Path) -> None:
+    upgrader = Upgrader("uv", ["uv", "tool", "upgrade", "job-hunter-kit"])
+    with (
+        patch("subprocess.run", return_value=_proc(0)) as mock_run,
+        patch("subprocess.Popen") as mock_popen,
+        patch("job_hunter.update.versions.installed_version", return_value="0.26"),
+    ):
+        result = self_update.run_self_update(tmp_path, upgrader, from_version="0.25")
+
+    assert result == {"ok": True, "stage": "done", "from": "0.25", "to": "0.26"}
+    assert mock_run.call_count == 2  # upgrade command, then `job-hunter update --yes`
+    mock_popen.assert_called_once()
+    assert mock_popen.call_args.args[0][:2] == ["job-hunter", "dash"]
+
+    stored = self_update.read_last_result()
+    assert stored == result
+
+
+def test_run_self_update_retries_upgrade_on_transient_failure_then_succeeds(tmp_path: Path) -> None:
+    upgrader = Upgrader("pip", ["pip", "install", "--upgrade", "job-hunter-kit"])
+    attempts = [_proc(1, stderr="locked"), _proc(1, stderr="locked"), _proc(0), _proc(0)]
+    with (
+        patch("subprocess.run", side_effect=attempts) as mock_run,
+        patch("subprocess.Popen"),
+        patch("job_hunter.update.versions.installed_version", return_value="0.26"),
+    ):
+        result = self_update.run_self_update(tmp_path, upgrader, from_version="0.25")
+
+    assert result["ok"] is True
+    assert mock_run.call_count == 4  # 2 failed upgrade attempts + 1 successful + workspace update
+
+
+def test_run_self_update_gives_up_after_max_retries_and_reports_fallback(tmp_path: Path) -> None:
+    upgrader = Upgrader("pip", ["pip", "install", "--upgrade", "job-hunter-kit"])
+    with (
+        patch("subprocess.run", return_value=_proc(1, stderr="permission denied")),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        result = self_update.run_self_update(tmp_path, upgrader, from_version="0.25")
+
+    assert result["ok"] is False
+    assert result["stage"] == "upgrade"
+    assert result["fallback_command"] == "pip install --upgrade job-hunter-kit"
+    mock_popen.assert_not_called()  # never relaunches on a failed upgrade
+    assert self_update.read_last_result() == result
+
+
+def test_run_self_update_reports_workspace_update_failure_separately(tmp_path: Path) -> None:
+    upgrader = Upgrader("uv", ["uv", "tool", "upgrade", "job-hunter-kit"])
+    with (
+        patch("subprocess.run", side_effect=[_proc(0), _proc(1, stderr="schema invalid")]),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        result = self_update.run_self_update(tmp_path, upgrader, from_version="0.25")
+
+    assert result["ok"] is False
+    assert result["stage"] == "workspace_update"
+    assert result["fallback_command"] == "job-hunter update --yes"
+    mock_popen.assert_not_called()
+
+
+def test_read_last_result_is_none_when_absent(tmp_path: Path) -> None:
+    assert self_update.read_last_result() is None
+
+
+def test_clear_last_result_is_idempotent(tmp_path: Path) -> None:
+    self_update.clear_last_result()
+    self_update.clear_last_result()

--- a/tests/test_update_snapshot.py
+++ b/tests/test_update_snapshot.py
@@ -1,0 +1,54 @@
+"""Tests for job_hunter/update/snapshot.py — snapshot/rollback of system-owned files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from job_hunter.update.snapshot import rollback_last, snapshot_system_files
+
+
+def _make_workspace(root: Path) -> None:
+    (root / "config" / "schemas").mkdir(parents=True)
+    (root / "config" / "schemas" / "job_hunter.schema.json").write_text('{"v": 1}', encoding="utf-8")
+    (root / "README.md").write_text("original readme", encoding="utf-8")
+    (root / ".claude" / "skills" / "job-hunter").mkdir(parents=True)
+    (root / ".claude" / "skills" / "job-hunter" / "SKILL.md").write_text("skill v1", encoding="utf-8")
+    # user-owned — must never be snapshotted or rolled back
+    (root / "config" / "job_hunter.yml").write_text("mode: agent\n", encoding="utf-8")
+
+
+def test_snapshot_then_rollback_restores_overwritten_system_files(tmp_path: Path) -> None:
+    _make_workspace(tmp_path)
+
+    count = snapshot_system_files(tmp_path)
+    assert count == 3  # README.md, schema.json, SKILL.md
+
+    # Simulate an update overwriting system files.
+    (tmp_path / "README.md").write_text("new readme", encoding="utf-8")
+    (tmp_path / ".claude" / "skills" / "job-hunter" / "SKILL.md").write_text("skill v2", encoding="utf-8")
+
+    restored = rollback_last(tmp_path)
+    assert restored == 3
+    assert (tmp_path / "README.md").read_text(encoding="utf-8") == "original readme"
+    assert (tmp_path / ".claude" / "skills" / "job-hunter" / "SKILL.md").read_text(encoding="utf-8") == "skill v1"
+
+
+def test_snapshot_never_captures_user_owned_files(tmp_path: Path) -> None:
+    _make_workspace(tmp_path)
+    snapshot_system_files(tmp_path)
+
+    snapshot_root = tmp_path / "outputs" / "state" / "update_snapshot"
+    assert not (snapshot_root / "config" / "job_hunter.yml").exists()
+
+
+def test_rollback_with_no_prior_snapshot_returns_zero(tmp_path: Path) -> None:
+    _make_workspace(tmp_path)
+    assert rollback_last(tmp_path) == 0
+
+
+def test_snapshot_replaces_prior_snapshot_rather_than_accumulating(tmp_path: Path) -> None:
+    _make_workspace(tmp_path)
+    snapshot_system_files(tmp_path)
+    (tmp_path / "README.md").unlink()  # next snapshot should reflect current (fewer) files
+    count = snapshot_system_files(tmp_path)
+    assert count == 2

--- a/tests/test_update_upgrader.py
+++ b/tests/test_update_upgrader.py
@@ -1,0 +1,56 @@
+"""Tests for job_hunter/update/upgrader.py — detect which tool manages the install."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from job_hunter.update.upgrader import Upgrader, detect_upgrader
+
+
+def _proc(returncode: int, stdout: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    return result
+
+
+def test_detect_upgrader_returns_none_for_frozen_build() -> None:
+    with patch.object(sys, "frozen", True, create=True):
+        assert detect_upgrader() is None
+
+
+def test_detect_upgrader_prefers_uv_when_uv_manages_the_package() -> None:
+    with (
+        patch("shutil.which", side_effect=lambda tool: f"/usr/bin/{tool}" if tool == "uv" else None),
+        patch("subprocess.run", return_value=_proc(0, "job-hunter-kit 0.25\n")),
+    ):
+        result = detect_upgrader()
+    assert result == Upgrader("uv", ["uv", "tool", "upgrade", "job-hunter-kit"])
+
+
+def test_detect_upgrader_falls_back_to_pipx_when_uv_does_not_manage_it() -> None:
+    def which(tool: str) -> str | None:
+        return f"/usr/bin/{tool}" if tool in ("uv", "pipx") else None
+
+    def run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        if cmd[0] == "uv":
+            return _proc(0, "some-other-package 1.0\n")
+        return _proc(0, "job-hunter-kit 0.25, ...\n")
+
+    with patch("shutil.which", side_effect=which), patch("subprocess.run", side_effect=run):
+        result = detect_upgrader()
+    assert result == Upgrader("pipx", ["pipx", "upgrade", "job-hunter-kit"])
+
+
+def test_detect_upgrader_falls_back_to_pip_when_neither_uv_nor_pipx_manage_it() -> None:
+    with patch("shutil.which", return_value=None):
+        result = detect_upgrader()
+    assert result == Upgrader("pip", [sys.executable, "-m", "pip", "install", "--upgrade", "job-hunter-kit"])
+
+
+def test_detect_upgrader_falls_back_to_pip_when_uv_missing_entirely() -> None:
+    with patch("shutil.which", return_value=None), patch("subprocess.run") as mock_run:
+        result = detect_upgrader()
+    mock_run.assert_not_called()
+    assert result.tool == "pip"

--- a/tests/test_update_versions.py
+++ b/tests/test_update_versions.py
@@ -1,0 +1,86 @@
+"""Tests for job_hunter/update/versions.py — PyPI version check, cache, offline tolerance."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from job_hunter.update import versions
+
+
+@pytest.fixture(autouse=True)
+def _isolated_platform_config_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+
+
+@pytest.mark.parametrize(
+    ("latest", "installed", "expected"),
+    [
+        ("0.26", "0.25", True),
+        ("0.25", "0.25", False),
+        ("0.24", "0.25", False),
+        ("1.0", "0.99", True),
+        ("v0.26", "0.25", True),  # non-numeric prefix ignored
+        ("unknown", "0.25", False),  # no digits at all -> (0,) <= anything real
+    ],
+)
+def test_is_newer(latest: str, installed: str, expected: bool) -> None:
+    assert versions.is_newer(latest, installed) is expected
+
+
+def test_latest_pypi_version_returns_none_on_request_failure() -> None:
+    with patch("requests.get", side_effect=RuntimeError("offline")):
+        assert versions.latest_pypi_version() is None
+
+
+def test_latest_pypi_version_returns_none_on_bad_status() -> None:
+    response = MagicMock()
+    response.raise_for_status.side_effect = RuntimeError("500")
+    with patch("requests.get", return_value=response):
+        assert versions.latest_pypi_version() is None
+
+
+def test_latest_pypi_version_parses_info_version() -> None:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"info": {"version": "0.26"}}
+    with patch("requests.get", return_value=response) as mock_get:
+        assert versions.latest_pypi_version() == "0.26"
+        assert mock_get.call_args.kwargs["timeout"] == 3.0
+
+
+def test_cached_status_with_no_cache_file() -> None:
+    with patch("job_hunter.config.loader.package_version", return_value="0.25"):
+        status = versions.cached_status()
+    assert status == {"installed": "0.25", "latest": None, "update_available": False, "checked_at": None}
+
+
+def test_cache_is_stale_true_with_no_cache_file() -> None:
+    assert versions.cache_is_stale() is True
+
+
+def test_refresh_cache_writes_and_cached_status_reflects_it() -> None:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"info": {"version": "0.26"}}
+    with (
+        patch("requests.get", return_value=response),
+        patch("job_hunter.config.loader.package_version", return_value="0.25"),
+    ):
+        result = versions.refresh_cache()
+        assert result["latest"] == "0.26"
+        assert result["update_available"] is True
+        assert versions.cache_is_stale() is False
+
+        status = versions.cached_status()
+    assert status["update_available"] is True
+    assert status["latest"] == "0.26"
+
+
+def test_refresh_cache_offline_leaves_cache_untouched_and_stays_stale() -> None:
+    with patch("requests.get", side_effect=RuntimeError("offline")):
+        result = versions.refresh_cache()
+    assert result["latest"] is None
+    assert versions.cache_is_stale() is True  # retry next time, not after a 24h wait

--- a/tests/test_update_versions.py
+++ b/tests/test_update_versions.py
@@ -61,6 +61,17 @@ def test_cache_is_stale_true_with_no_cache_file() -> None:
     assert versions.cache_is_stale() is True
 
 
+def test_cache_is_stale_accepts_a_checked_at_directly_without_reading_the_cache_file() -> None:
+    """DashAPI.get_update_status() passes cached_status()'s own "checked_at" here so a
+    single dashboard-startup call reads the cache file once, not twice."""
+    import time
+
+    assert versions.cache_is_stale(time.time()) is False
+    assert versions.cache_is_stale(time.time() - versions._CACHE_TTL_SECONDS - 1) is True
+    assert versions.cache_is_stale(None) is True
+    assert versions.cache_is_stale("not-a-number") is True
+
+
 def test_refresh_cache_writes_and_cached_status_reflects_it() -> None:
     response = MagicMock()
     response.raise_for_status.return_value = None

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -2939,3 +2939,110 @@ def test_settings_and_wizard_show_per_language_resume_coverage() -> None:
     assert 'id="wizard-resume-coverage"' in html
     assert "resume_languages" in html
     assert "resume_base_lang" in html
+
+
+# ── One-click update (job_hunter/update/) ──
+
+
+@pytest.fixture(autouse=True)
+def _isolated_update_state_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """update/versions.py + update/self_update.py store their cache/state in
+    platform_config_dir(), not the workspace — isolate it from the real %APPDATA%/~/.config
+    the same way tests/test_launcher.py does."""
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+
+
+def test_update_banner_markup_and_handlers_present() -> None:
+    html = _dashboard_source()
+
+    assert 'id="update-banner"' in html
+    assert "get_update_status" in html
+    assert "get_update_changelog" in html
+    assert "start_self_update" in html
+    assert "get_last_update_result" in html
+
+
+def test_get_update_status_with_no_cache_reports_no_update_available(tmp_path: Path) -> None:
+    payload = DashAPI(tmp_path).get_update_status()
+
+    assert payload["ok"] is True
+    assert payload["update_available"] is False
+    assert payload["latest"] is None
+
+
+def test_get_update_status_reflects_cached_newer_version(tmp_path: Path) -> None:
+    from unittest.mock import MagicMock, patch
+
+    from job_hunter.update import versions
+
+    with (
+        patch("job_hunter.config.loader.package_version", return_value="0.25"),
+        patch("requests.get") as mock_get,
+    ):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"info": {"version": "0.99"}}
+        mock_get.return_value = response
+        versions.refresh_cache()
+
+        payload = DashAPI(tmp_path).get_update_status()
+
+    assert payload["update_available"] is True
+    assert payload["latest"] == "0.99"
+
+
+def test_get_last_update_result_is_none_then_consumes_a_stored_result(tmp_path: Path) -> None:
+    from job_hunter.update.self_update import _write_result
+
+    api = DashAPI(tmp_path)
+    assert api.get_last_update_result() == {"ok": True, "status": "none"}
+
+    _write_result({"ok": True, "stage": "done", "from": "0.25", "to": "0.26"})
+    first = api.get_last_update_result()
+    assert first == {"ok": True, "status": "done", "stage": "done", "from": "0.25", "to": "0.26"}
+
+    # Consumed — a second call must not re-show the same toast.
+    assert api.get_last_update_result() == {"ok": True, "status": "none"}
+
+
+def test_start_self_update_refuses_while_a_hunt_is_running(tmp_path: Path) -> None:
+    api = DashAPI(tmp_path)
+    api._hunt_running = True
+
+    result = api.start_self_update()
+
+    assert result == {"ok": False, "status": "running", "error": "A hunt is running — try updating after it finishes."}
+
+
+def test_start_self_update_reports_fallback_command_when_upgrader_undetectable(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    with patch("job_hunter.update.upgrader.detect_upgrader", return_value=None):
+        result = DashAPI(tmp_path).start_self_update()
+
+    assert result["ok"] is False
+    assert "fallback_command" in result
+
+
+def test_start_self_update_snapshots_then_spawns_detached_helper(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    from job_hunter.update.upgrader import Upgrader
+
+    (tmp_path / "README.md").write_text("readme", encoding="utf-8")
+    api = DashAPI(tmp_path)
+
+    with (
+        patch("job_hunter.update.upgrader.detect_upgrader", return_value=Upgrader("uv", ["uv", "tool", "upgrade"])),
+        patch("subprocess.Popen") as mock_popen,
+        patch("threading.Thread") as mock_thread,
+    ):
+        result = api.start_self_update()
+
+    assert result == {"ok": True, "status": "restarting"}
+    mock_popen.assert_called_once()
+    spawned = mock_popen.call_args.args[0]
+    assert spawned[:3] == ["job-hunter", "internal", "self-update"]
+    assert (tmp_path / "outputs" / "state" / "update_snapshot" / "README.md").read_text(encoding="utf-8") == "readme"
+    mock_thread.assert_called_once()


### PR DESCRIPTION
## Summary
- **Layer 1 — in-app one-click update**: new `job_hunter/update/` package (PyPI version check with 24h cache, uv/pipx/pip upgrader detection, snapshot/rollback of system-owned files, GitHub changelog lookup, detached self-update helper), DashAPI methods, CLI commands (`internal self-update`, `internal rollback-update`), and a dashboard "Update now" banner. Non-blocking startup by construction; upgrade delegates to uv/pip's own download+cache.
- **Layer 2 — native installers**: found and fixed a real bug while building — the PyInstaller specs (Windows/macOS/Linux) still referenced `catalog/companies.json`, deleted after the companies architecture migrated to a runtime store; the Windows build failed outright until fixed (verified by actually building the frozen exe and running `internal self-test`/`doctor` against it — 4087 companies now load correctly). Added `packaging/windows/job-hunter.iss` (Inno Setup), `packaging/macos/build_pkg.sh`, `packaging/linux/install.sh`, and a `build-installers` matrix job in `release.yml` (still `workflow_dispatch`-only, not triggered by this PR).
- **Layer 3 — first-run desktop shortcut**: `job_hunter/shortcut.py` registers a Start Menu `.lnk` (Windows) or `.desktop` entry (Linux) on first `dash` launch; opt-out via `--no-shortcut`. macOS defers to the `.app` bundle.
- Zero new user-editable config files or schema changes — all new state lives in `platform_config_dir()` or `outputs/state/`.
- Docs updated: README, workspace `SETUP.md`, `docs/workspace-updates.md`, `docs/{windows,macos,linux}-packaging.md`.

## Known limitations
- Windows/macOS installers are unsigned (SmartScreen/Gatekeeper warnings until certificates exist).
- The Inno Setup script and macOS `.pkg` script are authored but not compiled in this dev environment (no Inno Setup toolchain, no Mac hardware) — the GitHub Actions matrix will be the first real validation of those two.

## Test plan
- [x] `uv run pytest tests/ -q --tb=short` — 1748 passed
- [x] `uv run ruff format --check` / `ruff check` / `ty check` — clean
- [x] `tests/test_dependency_boundaries.py` — clean
- [x] `scripts/sync_workspace_template.py --check` — clean
- [x] Built the Windows PyInstaller bundle locally and smoke-tested `--help`, `version`, `internal self-test --json`, `init`, `doctor`, `internal self-update --help`
- [ ] GitHub Actions `build-installers` matrix (Windows/macOS) — first real validation, not run yet
- [ ] Manual click-through of the dashboard "Update now" banner and the new installers